### PR TITLE
feat: create bank search plugin

### DIFF
--- a/src/renderer/client/client.ts
+++ b/src/renderer/client/client.ts
@@ -17,7 +17,7 @@ import { DropLog } from "./highlite/plugins/DropLog";
 import { ChatItemTooltip } from "./highlite/plugins/ChatItemTooltip";
 import { XPOrb } from "./highlite/plugins/XPOrb";
 import { TreasureMapHelper } from "./highlite/plugins/TreasureMapHelper";
-import { BankSearch } from "./highlite/plugins/BankHelper";
+import { BankSearch } from "./highlite/plugins/BankSearch";
 import { FPSLimiter } from "./highlite/plugins/FPSLimiter";
 import { DefinitionsPanel } from "./highlite/plugins/DefinitionsPanel";
 import { MinimapIcons } from "./highlite/plugins/MinimapIcons";
@@ -58,7 +58,7 @@ const PLUGIN_REGISTRY = [
     { class: FPSLimiter, path: './highlite/plugins/FPSLimiter' },
     { class: DefinitionsPanel, path: './highlite/plugins/DefinitionsPanel'},
     { class: MinimapIcons, path: './highlite/plugins/MinimapIcons'},
-    { class: BankSearch, path: './highlite/plugins/BankHelper'}
+    { class: BankSearch, path: './highlite/plugins/BankSearch'}
 ];
 
 async function obtainGameClient() {

--- a/src/renderer/client/client.ts
+++ b/src/renderer/client/client.ts
@@ -1,26 +1,27 @@
-import { IndexDBWrapper } from './helpers/IndexDBWrapper';
-import { Highlite } from './highlite/core/core';
-import { HPAlert } from './highlite/plugins/HPAlert';
-import { IdleAlert } from './highlite/plugins/IdleAlert/IdleAlert';
-import { Lookup } from './highlite/plugins/Lookup';
-import { Nameplates } from './highlite/plugins/Nameplates';
-import { EnhancedHPBars } from './highlite/plugins/EnhancedHPBars';
-import { EnhancedLoginScreen } from './highlite/plugins/EnhancedLoginScreen';
-import { ContextMenuOptions } from './highlite/plugins/ContextMenuOptions';
-import { TradeAlerts } from './highlite/plugins/TradeAlerts';
-import { PMAlerts } from './highlite/plugins/PMAlerts';
-import { CoinCounter } from './highlite/plugins/CoinCounter';
-import { ExperienceTracker } from './highlite/plugins/ExperienceTracker';
-import { WorldMap } from './highlite/plugins/Map';
-import { MinimapMarker } from './highlite/plugins/MinimapMarker';
-import { DropLog } from './highlite/plugins/DropLog';
-import { ChatItemTooltip } from './highlite/plugins/ChatItemTooltip';
-import { XPOrb } from './highlite/plugins/XPOrb';
-import { TreasureMapHelper } from './highlite/plugins/TreasureMapHelper';
-import { FPSLimiter } from './highlite/plugins/FPSLimiter';
-import { DefinitionsPanel } from './highlite/plugins/DefinitionsPanel';
-import { MinimapIcons } from './highlite/plugins/MinimapIcons';
-import { setupWorldSelectorObserver } from './helpers/worldSelectHelper';
+import { IndexDBWrapper } from "./helpers/IndexDBWrapper";
+import { Highlite } from "./highlite/core/core";
+import { HPAlert } from "./highlite/plugins/HPAlert";
+import { IdleAlert } from "./highlite/plugins/IdleAlert/IdleAlert";
+import { Lookup } from "./highlite/plugins/Lookup";
+import { Nameplates } from "./highlite/plugins/Nameplates";
+import { EnhancedHPBars } from "./highlite/plugins/EnhancedHPBars";
+import { EnhancedLoginScreen } from "./highlite/plugins/EnhancedLoginScreen";
+import { ContextMenuOptions } from "./highlite/plugins/ContextMenuOptions";
+import { TradeAlerts } from "./highlite/plugins/TradeAlerts";
+import { PMAlerts } from "./highlite/plugins/PMAlerts";
+import { CoinCounter } from "./highlite/plugins/CoinCounter";
+import { ExperienceTracker } from "./highlite/plugins/ExperienceTracker";
+import { WorldMap } from "./highlite/plugins/Map";
+import { MinimapMarker } from "./highlite/plugins/MinimapMarker";
+import { DropLog } from "./highlite/plugins/DropLog";
+import { ChatItemTooltip } from "./highlite/plugins/ChatItemTooltip";
+import { XPOrb } from "./highlite/plugins/XPOrb";
+import { TreasureMapHelper } from "./highlite/plugins/TreasureMapHelper";
+import { BankSearch } from "./highlite/plugins/BankHelper";
+import { FPSLimiter } from "./highlite/plugins/FPSLimiter";
+import { DefinitionsPanel } from "./highlite/plugins/DefinitionsPanel";
+import { MinimapIcons } from "./highlite/plugins/MinimapIcons";
+import { setupWorldSelectorObserver } from "./helpers/worldSelectHelper";
 
 import '@static/css/index.css';
 import '@static/css/overrides.css';
@@ -55,8 +56,9 @@ const PLUGIN_REGISTRY = [
     { class: XPOrb, path: './highlite/plugins/XPOrb' },
     { class: TreasureMapHelper, path: './highlite/plugins/TreasureMapHelper' },
     { class: FPSLimiter, path: './highlite/plugins/FPSLimiter' },
-    { class: DefinitionsPanel, path: './highlite/plugins/DefinitionsPanel' },
-    { class: MinimapIcons, path: './highlite/plugins/MinimapIcons' },
+    { class: DefinitionsPanel, path: './highlite/plugins/DefinitionsPanel'},
+    { class: MinimapIcons, path: './highlite/plugins/MinimapIcons'},
+    { class: BankSearch, path: './highlite/plugins/BankHelper'}
 ];
 
 async function obtainGameClient() {

--- a/src/renderer/client/client.ts
+++ b/src/renderer/client/client.ts
@@ -1,27 +1,27 @@
-import { IndexDBWrapper } from "./helpers/IndexDBWrapper";
-import { Highlite } from "./highlite/core/core";
-import { HPAlert } from "./highlite/plugins/HPAlert";
-import { IdleAlert } from "./highlite/plugins/IdleAlert/IdleAlert";
-import { Lookup } from "./highlite/plugins/Lookup";
-import { Nameplates } from "./highlite/plugins/Nameplates";
-import { EnhancedHPBars } from "./highlite/plugins/EnhancedHPBars";
-import { EnhancedLoginScreen } from "./highlite/plugins/EnhancedLoginScreen";
-import { ContextMenuOptions } from "./highlite/plugins/ContextMenuOptions";
-import { TradeAlerts } from "./highlite/plugins/TradeAlerts";
-import { PMAlerts } from "./highlite/plugins/PMAlerts";
-import { CoinCounter } from "./highlite/plugins/CoinCounter";
-import { ExperienceTracker } from "./highlite/plugins/ExperienceTracker";
-import { WorldMap } from "./highlite/plugins/Map";
-import { MinimapMarker } from "./highlite/plugins/MinimapMarker";
-import { DropLog } from "./highlite/plugins/DropLog";
-import { ChatItemTooltip } from "./highlite/plugins/ChatItemTooltip";
-import { XPOrb } from "./highlite/plugins/XPOrb";
-import { TreasureMapHelper } from "./highlite/plugins/TreasureMapHelper";
-import { BankSearch } from "./highlite/plugins/BankSearch";
-import { FPSLimiter } from "./highlite/plugins/FPSLimiter";
-import { DefinitionsPanel } from "./highlite/plugins/DefinitionsPanel";
-import { MinimapIcons } from "./highlite/plugins/MinimapIcons";
-import { setupWorldSelectorObserver } from "./helpers/worldSelectHelper";
+import { IndexDBWrapper } from './helpers/IndexDBWrapper';
+import { Highlite } from './highlite/core/core';
+import { HPAlert } from './highlite/plugins/HPAlert';
+import { IdleAlert } from './highlite/plugins/IdleAlert/IdleAlert';
+import { Lookup } from './highlite/plugins/Lookup';
+import { Nameplates } from './highlite/plugins/Nameplates';
+import { EnhancedHPBars } from './highlite/plugins/EnhancedHPBars';
+import { EnhancedLoginScreen } from './highlite/plugins/EnhancedLoginScreen';
+import { ContextMenuOptions } from './highlite/plugins/ContextMenuOptions';
+import { TradeAlerts } from './highlite/plugins/TradeAlerts';
+import { PMAlerts } from './highlite/plugins/PMAlerts';
+import { CoinCounter } from './highlite/plugins/CoinCounter';
+import { ExperienceTracker } from './highlite/plugins/ExperienceTracker';
+import { WorldMap } from './highlite/plugins/Map';
+import { MinimapMarker } from './highlite/plugins/MinimapMarker';
+import { DropLog } from './highlite/plugins/DropLog';
+import { ChatItemTooltip } from './highlite/plugins/ChatItemTooltip';
+import { XPOrb } from './highlite/plugins/XPOrb';
+import { TreasureMapHelper } from './highlite/plugins/TreasureMapHelper';
+import { BankSearch } from './highlite/plugins/BankSearch';
+import { FPSLimiter } from './highlite/plugins/FPSLimiter';
+import { DefinitionsPanel } from './highlite/plugins/DefinitionsPanel';
+import { MinimapIcons } from './highlite/plugins/MinimapIcons';
+import { setupWorldSelectorObserver } from './helpers/worldSelectHelper';
 
 import '@static/css/index.css';
 import '@static/css/overrides.css';
@@ -56,9 +56,9 @@ const PLUGIN_REGISTRY = [
     { class: XPOrb, path: './highlite/plugins/XPOrb' },
     { class: TreasureMapHelper, path: './highlite/plugins/TreasureMapHelper' },
     { class: FPSLimiter, path: './highlite/plugins/FPSLimiter' },
-    { class: DefinitionsPanel, path: './highlite/plugins/DefinitionsPanel'},
-    { class: MinimapIcons, path: './highlite/plugins/MinimapIcons'},
-    { class: BankSearch, path: './highlite/plugins/BankSearch'}
+    { class: DefinitionsPanel, path: './highlite/plugins/DefinitionsPanel' },
+    { class: MinimapIcons, path: './highlite/plugins/MinimapIcons' },
+    { class: BankSearch, path: './highlite/plugins/BankSearch' },
 ];
 
 async function obtainGameClient() {

--- a/src/renderer/client/highlite/core/core.ts
+++ b/src/renderer/client/highlite/core/core.ts
@@ -60,6 +60,7 @@ export class Highlite {
         this.hookManager.registerClass('HR', 'HR'); // Potential name: UIManager?
         this.hookManager.registerClass('dH', 'InventoryItemSpriteManager');
         this.hookManager.registerClass('DP', 'ItemDefMap');
+        this.hookManager.registerClass('bz', 'BankUIManager');
         // this.hookManager.registerClass("LF", "MainPlayer");
         this.hookManager.registerClass('eR', 'GameCameraManager'); // Tip to find: contains call initializeCamera(e ,t)
         this.hookManager.registerClass('Ck', 'SpriteSheetManager'); //Tip to find: contains getter PlayerSpritesheetInfo
@@ -69,36 +70,18 @@ export class Highlite {
         this.hookManager.registerClass('SR', 'BlobLoader');
 
         // Function Hook-ins
-        this.hookManager.registerClassOverrideHook(
-            'LoginScreen',
-            '_handleRegisterButtonClicked',
-            this.loginHooks
-        );
-        this.hookManager.registerClassOverrideHook(
-            'LoginScreen',
-            '_handleHomeButtonClicked',
-            this.loginHooks
-        );
-        this.hookManager.registerClassHook('GameLoop', '_update');
-        this.hookManager.registerClassHook('GameLoop', '_draw');
-        this.hookManager.registerClassHook(
-            'PrivateChatMessageList',
-            'addChatMessage'
-        );
-        this.hookManager.registerClassHook('SocketManager', '_loggedIn');
-        this.hookManager.registerClassHook('SocketManager', '_handleLoggedOut');
-        this.hookManager.registerClassHook(
-            'SocketManager',
-            '_handleEnteredIdleStateAction'
-        );
-        this.hookManager.registerClassHook(
-            'SocketManager',
-            '_handleTradeRequestedPacket'
-        );
-        this.hookManager.registerClassHook(
-            'SocketManager',
-            '_handleInvokedInventoryItemActionPacket'
-        );
+        this.hookManager.registerClassOverrideHook("LoginScreen", "_handleRegisterButtonClicked", this.loginHooks);
+        this.hookManager.registerClassOverrideHook("LoginScreen", "_handleHomeButtonClicked", this.loginHooks);
+        this.hookManager.registerClassHook("GameLoop", "_update");
+        this.hookManager.registerClassHook("GameLoop", "_draw");
+        this.hookManager.registerClassHook("PrivateChatMessageList", "addChatMessage");
+        this.hookManager.registerClassHook("SocketManager", "_loggedIn");
+        this.hookManager.registerClassHook("SocketManager", "_handleLoggedOut");
+        this.hookManager.registerClassHook("SocketManager", "_handleEnteredIdleStateAction");
+        this.hookManager.registerClassHook("SocketManager", "_handleTradeRequestedPacket");
+        this.hookManager.registerClassHook("SocketManager", "_handleInvokedInventoryItemActionPacket");
+        this.hookManager.registerClassHook("BankUIManager", "showBankMenu")
+        this.hookManager.registerClassHook("BankUIManager", "_handleCenterMenuWillBeRemoved")
 
         // Needs Naming
         this.contextMenuManager.registerContextHook(

--- a/src/renderer/client/highlite/core/core.ts
+++ b/src/renderer/client/highlite/core/core.ts
@@ -70,18 +70,41 @@ export class Highlite {
         this.hookManager.registerClass('SR', 'BlobLoader');
 
         // Function Hook-ins
-        this.hookManager.registerClassOverrideHook("LoginScreen", "_handleRegisterButtonClicked", this.loginHooks);
-        this.hookManager.registerClassOverrideHook("LoginScreen", "_handleHomeButtonClicked", this.loginHooks);
-        this.hookManager.registerClassHook("GameLoop", "_update");
-        this.hookManager.registerClassHook("GameLoop", "_draw");
-        this.hookManager.registerClassHook("PrivateChatMessageList", "addChatMessage");
-        this.hookManager.registerClassHook("SocketManager", "_loggedIn");
-        this.hookManager.registerClassHook("SocketManager", "_handleLoggedOut");
-        this.hookManager.registerClassHook("SocketManager", "_handleEnteredIdleStateAction");
-        this.hookManager.registerClassHook("SocketManager", "_handleTradeRequestedPacket");
-        this.hookManager.registerClassHook("SocketManager", "_handleInvokedInventoryItemActionPacket");
-        this.hookManager.registerClassHook("BankUIManager", "showBankMenu")
-        this.hookManager.registerClassHook("BankUIManager", "_handleCenterMenuWillBeRemoved")
+        this.hookManager.registerClassOverrideHook(
+            'LoginScreen',
+            '_handleRegisterButtonClicked',
+            this.loginHooks
+        );
+        this.hookManager.registerClassOverrideHook(
+            'LoginScreen',
+            '_handleHomeButtonClicked',
+            this.loginHooks
+        );
+        this.hookManager.registerClassHook('GameLoop', '_update');
+        this.hookManager.registerClassHook('GameLoop', '_draw');
+        this.hookManager.registerClassHook(
+            'PrivateChatMessageList',
+            'addChatMessage'
+        );
+        this.hookManager.registerClassHook('SocketManager', '_loggedIn');
+        this.hookManager.registerClassHook('SocketManager', '_handleLoggedOut');
+        this.hookManager.registerClassHook(
+            'SocketManager',
+            '_handleEnteredIdleStateAction'
+        );
+        this.hookManager.registerClassHook(
+            'SocketManager',
+            '_handleTradeRequestedPacket'
+        );
+        this.hookManager.registerClassHook(
+            'SocketManager',
+            '_handleInvokedInventoryItemActionPacket'
+        );
+        this.hookManager.registerClassHook('BankUIManager', 'showBankMenu');
+        this.hookManager.registerClassHook(
+            'BankUIManager',
+            '_handleCenterMenuWillBeRemoved'
+        );
 
         // Needs Naming
         this.contextMenuManager.registerContextHook(

--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -235,7 +235,7 @@ export class BankSearch extends Plugin {
     highlightBankQuery(query) {
         // Get bank items from the game data
         const bankItems =
-            (document as any).highlite?.gameHooks?.EntityManager?.Instance
+            document.highlite?.gameHooks?.EntityManager?.Instance
                 ?.MainPlayer?._bankItems?.Items || [];
 
         // Find all bank item elements by data-slot attribute
@@ -261,11 +261,9 @@ export class BankSearch extends Plugin {
             if (!bankItem) continue; // Skip null/empty slots
 
             // Get item definition
-            const itemDef = (document as any).highlite?.gameHooks?.ItemDefMap
+            const itemDef = document.highlite?.gameHooks?.ItemDefMap
                 ?.ItemDefMap?.get
-                ? (
-                      document as any
-                  ).highlite.gameHooks.ItemDefMap.ItemDefMap.get(bankItem._id)
+                ? document.highlite.gameHooks.ItemDefMap.ItemDefMap.get(bankItem._id)
                 : null;
 
             const itemName = itemDef

--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -1,168 +1,169 @@
-import { Plugin } from "../core/interfaces/highlite/plugin/plugin.class";
-
+import { Plugin } from '../core/interfaces/highlite/plugin/plugin.class';
 
 export class BankSearch extends Plugin {
-  pluginName = "Bank Search";
-  author = "Oatelaus";
+    pluginName = 'Bank Search';
+    author = 'Oatelaus';
 
-  private searchBox: HTMLElement | null = null;
-  private resizeListener: (() => void) | null = null;
-  private lastQuery: string = "";
+    private searchBox: HTMLElement | null = null;
+    private resizeListener: (() => void) | null = null;
+    private lastQuery: string = '';
 
-  constructor() {
-    super();
-  }
-
-  start(): void {
-    if (!this.settings.enable.value) {
-      return;
-    }
-    this.injectSearchBox();
-    this.updateSearchBoxVisibility();
-  }
-
-  init(): void {
-  }
-
-  stop(): void {
-    this.destroy()
-  }
-
-
-  BankUIManager_showBankMenu() {
-    if (!this.settings.enable.value) {
-      return;
-    }
-    this.injectSearchBox();
-    this.updateSearchBoxVisibility();
-  }
-
-  BankUIManager_handleCenterMenuWillBeRemoved() {
-    this.destroy();
-  }
-
-  updateSearchBoxVisibility() {
-    const bankMenu = document.getElementById('hs-bank-menu');
-    if (!bankMenu) {
-      this.removeSearchBox();
-      return;
+    constructor() {
+        super();
     }
 
-    // Check if bank is visible
-    const isVisible = this.isBankVisible(bankMenu);
-
-    if (isVisible && !this.searchBox) {
-      this.injectSearchBox();
-    } else if (!isVisible && this.searchBox) {
-      this.removeSearchBox();
-    }
-  }
-
-  isBankVisible(bankMenu: HTMLElement): boolean {
-    // Check if the bank menu is visible
-    const style = window.getComputedStyle(bankMenu);
-    if (style.display === 'none' || style.visibility === 'hidden') {
-      return false;
-    }
-
-    // Check if parent containers are visible
-    let parent = bankMenu.parentElement;
-    while (parent) {
-      const parentStyle = window.getComputedStyle(parent);
-      if (parentStyle.display === 'none' || parentStyle.visibility === 'hidden') {
-        return false;
-      }
-      parent = parent.parentElement;
-    }
-
-    // Check if bank menu has any content (indicating it's actually open)
-    const hasItems = bankMenu.querySelectorAll('[data-slot]').length > 0;
-    return hasItems;
-  }
-
-  injectSearchBox() {
-    // Prevent duplicate injection - check both internal reference and DOM presence
-    if (this.searchBox || document.getElementById('bank-helper-search-box')) return;
-
-    // Find the bank menu container to position relative to it
-    const bankMenu = document.getElementById('hs-bank-menu');
-    if (!bankMenu) return;
-
-    // Create the search box container
-    const searchContainer = document.createElement('div');
-    searchContainer.id = 'bank-helper-search-box';
-    searchContainer.classList.add('hs-menu');
-    searchContainer.classList.add('bank-helper-search-container');
-    this.searchBox = searchContainer;
-    searchContainer.style.position = 'fixed';
-    searchContainer.style.zIndex = '9999';
-    searchContainer.style.display = 'flex';
-    searchContainer.style.alignItems = 'center';
-    searchContainer.style.gap = '8px';
-    searchContainer.style.width = '300px';
-    searchContainer.style.boxSizing = 'border-box';
-
-    // Create the input
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.placeholder = 'Find bank item...';
-    input.classList.add('bank-helper-search-input');
-    input.style.width = '180px';
-    input.style.outline = 'none';
-    input.value = this.lastQuery; // Set input value to last query
-
-    // Prevent game from processing keystrokes while typing
-    input.addEventListener('keydown', (e) => e.stopPropagation());
-    input.addEventListener('keyup', (e) => e.stopPropagation());
-    input.addEventListener('keypress', (e) => e.stopPropagation());
-
-    // Add focus styling and prevent focus stealing (matching other plugins)
-    input.addEventListener('focus', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      input.classList.add('bank-helper-search-input-focused');
-    });
-    input.addEventListener('blur', () => {
-      input.classList.remove('bank-helper-search-input-focused');
-    });
-
-    // Prevent focus stealing on mousedown
-    searchContainer.addEventListener('mousedown', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      input.focus();
-    });
-
-    // Add search icon
-    const icon = document.createElement('span');
-    icon.textContent = '🔍';
-    icon.classList.add('bank-helper-search-icon');
-
-    searchContainer.appendChild(input);
-    searchContainer.appendChild(icon);
-    
-    // Position the search box below the bank menu
-    this.positionSearchBox(searchContainer, bankMenu);
-    
-    // Append to document body to avoid overflow clipping
-    document.body.appendChild(searchContainer);
-    
-    // Add resize listener to reposition search box
-    this.resizeListener = () => {
-      if (this.searchBox) {
-        const bankMenu = document.getElementById('hs-bank-menu');
-        if (bankMenu) {
-          this.positionSearchBox(this.searchBox, bankMenu);
+    start(): void {
+        if (!this.settings.enable.value) {
+            return;
         }
-      }
-    };
-    window.addEventListener('resize', this.resizeListener);
+        this.injectSearchBox();
+        this.updateSearchBoxVisibility();
+    }
 
-    // Add highlight style
-    if (!document.getElementById('bank-helper-highlight-style')) {
-      const style = document.createElement('style');
-      style.id = 'bank-helper-highlight-style';
-      style.textContent = `
+    init(): void {}
+
+    stop(): void {
+        this.destroy();
+    }
+
+    BankUIManager_showBankMenu() {
+        if (!this.settings.enable.value) {
+            return;
+        }
+        this.injectSearchBox();
+        this.updateSearchBoxVisibility();
+    }
+
+    BankUIManager_handleCenterMenuWillBeRemoved() {
+        this.destroy();
+    }
+
+    updateSearchBoxVisibility() {
+        const bankMenu = document.getElementById('hs-bank-menu');
+        if (!bankMenu) {
+            this.removeSearchBox();
+            return;
+        }
+
+        // Check if bank is visible
+        const isVisible = this.isBankVisible(bankMenu);
+
+        if (isVisible && !this.searchBox) {
+            this.injectSearchBox();
+        } else if (!isVisible && this.searchBox) {
+            this.removeSearchBox();
+        }
+    }
+
+    isBankVisible(bankMenu: HTMLElement): boolean {
+        // Check if the bank menu is visible
+        const style = window.getComputedStyle(bankMenu);
+        if (style.display === 'none' || style.visibility === 'hidden') {
+            return false;
+        }
+
+        // Check if parent containers are visible
+        let parent = bankMenu.parentElement;
+        while (parent) {
+            const parentStyle = window.getComputedStyle(parent);
+            if (
+                parentStyle.display === 'none' ||
+                parentStyle.visibility === 'hidden'
+            ) {
+                return false;
+            }
+            parent = parent.parentElement;
+        }
+
+        // Check if bank menu has any content (indicating it's actually open)
+        const hasItems = bankMenu.querySelectorAll('[data-slot]').length > 0;
+        return hasItems;
+    }
+
+    injectSearchBox() {
+        // Prevent duplicate injection - check both internal reference and DOM presence
+        if (this.searchBox || document.getElementById('bank-helper-search-box'))
+            return;
+
+        // Find the bank menu container to position relative to it
+        const bankMenu = document.getElementById('hs-bank-menu');
+        if (!bankMenu) return;
+
+        // Create the search box container
+        const searchContainer = document.createElement('div');
+        searchContainer.id = 'bank-helper-search-box';
+        searchContainer.classList.add('hs-menu');
+        searchContainer.classList.add('bank-helper-search-container');
+        this.searchBox = searchContainer;
+        searchContainer.style.position = 'fixed';
+        searchContainer.style.zIndex = '9999';
+        searchContainer.style.display = 'flex';
+        searchContainer.style.alignItems = 'center';
+        searchContainer.style.gap = '8px';
+        searchContainer.style.width = '300px';
+        searchContainer.style.boxSizing = 'border-box';
+
+        // Create the input
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.placeholder = 'Find bank item...';
+        input.classList.add('bank-helper-search-input');
+        input.style.width = '180px';
+        input.style.outline = 'none';
+        input.value = this.lastQuery; // Set input value to last query
+
+        // Prevent game from processing keystrokes while typing
+        input.addEventListener('keydown', e => e.stopPropagation());
+        input.addEventListener('keyup', e => e.stopPropagation());
+        input.addEventListener('keypress', e => e.stopPropagation());
+
+        // Add focus styling and prevent focus stealing (matching other plugins)
+        input.addEventListener('focus', e => {
+            e.preventDefault();
+            e.stopPropagation();
+            input.classList.add('bank-helper-search-input-focused');
+        });
+        input.addEventListener('blur', () => {
+            input.classList.remove('bank-helper-search-input-focused');
+        });
+
+        // Prevent focus stealing on mousedown
+        searchContainer.addEventListener('mousedown', e => {
+            e.preventDefault();
+            e.stopPropagation();
+            input.focus();
+        });
+
+        // Add search icon
+        const icon = document.createElement('span');
+        icon.textContent = '🔍';
+        icon.classList.add('bank-helper-search-icon');
+
+        searchContainer.appendChild(input);
+        searchContainer.appendChild(icon);
+
+        // Position the search box below the bank menu
+        this.positionSearchBox(searchContainer, bankMenu);
+
+        // Append to document body to avoid overflow clipping
+        document.body.appendChild(searchContainer);
+
+        // Add resize listener to reposition search box
+        this.resizeListener = () => {
+            if (this.searchBox) {
+                const bankMenu = document.getElementById('hs-bank-menu');
+                if (bankMenu) {
+                    this.positionSearchBox(this.searchBox, bankMenu);
+                }
+            }
+        };
+        window.addEventListener('resize', this.resizeListener);
+
+        // Add highlight style
+        if (!document.getElementById('bank-helper-highlight-style')) {
+            const style = document.createElement('style');
+            style.id = 'bank-helper-highlight-style';
+            style.textContent = `
         .bank-helper-search-container {
           padding: 0px;
         }
@@ -192,108 +193,125 @@ export class BankSearch extends Plugin {
           transition: opacity 0.2s, filter 0.2s;
         }
       `;
-      document.head.appendChild(style);
-    }
-
-    // Input event
-    input.addEventListener('input', (e) => {
-      const query = input.value.trim().toLowerCase();
-      this.lastQuery = query; // Store the last query
-      this.highlightBankQuery(query);
-    });
-    // If there is a last query, immediately highlight
-    if (this.lastQuery) {
-      this.highlightBankQuery(this.lastQuery);
-    }
-  }
-
-  positionSearchBox(searchContainer: HTMLElement, bankMenu: HTMLElement) {
-    const bankRect = bankMenu.getBoundingClientRect();
-    
-    // Position the search box below the bank menu
-    searchContainer.style.left = `${bankRect.left}px`;
-    searchContainer.style.top = `${bankRect.bottom + 8}px`;
-  }
-
-  removeSearchBox() {
-    // Remove all instances of the search box (in case of duplicates)
-    const existingSearchBoxes = document.querySelectorAll('#bank-helper-search-box');
-    existingSearchBoxes.forEach(box => box.remove());
-    
-    this.searchBox = null;
-    
-    // Remove resize listener
-    if (this.resizeListener) {
-      window.removeEventListener('resize', this.resizeListener);
-      this.resizeListener = null;
-    }
-  }
-
-  highlightBankQuery(query) {
-    // Get bank items from the game data
-    const bankItems = ((document as any).highlite?.gameHooks?.EntityManager?.Instance?.MainPlayer?._bankItems?.Items) || [];
-    
-    // Find all bank item elements by data-slot attribute
-    const bankMenu = document.getElementById('hs-bank-menu');
-    if (!bankMenu) return;
-    
-    // Query all elements with data-slot attribute
-    const itemElements = Array.from(bankMenu.querySelectorAll('[data-slot]'));
-    
-    // If query is empty, remove all grey-out effects
-    if (!query) {
-      itemElements.forEach(el => {
-        el.classList.remove('bank-helper-greyed-out');
-      });
-      return;
-    }
-    
-    // Loop through bank items and apply grey-out effect to non-matching items
-    for (let i = 0; i < bankItems.length; i++) {
-      const bankItem = bankItems[i];
-      if (!bankItem) continue; // Skip null/empty slots
-      
-      // Get item definition
-      const itemDef = ((document as any).highlite?.gameHooks?.ItemDefMap?.ItemDefMap?.get)
-        ? (document as any).highlite.gameHooks.ItemDefMap.ItemDefMap.get(bankItem._id)
-        : null;
-      
-      const itemName = itemDef ? (itemDef._nameCapitalized || itemDef._name || `Item ${bankItem._id}`) : `Item ${bankItem._id}`;
-      
-      // Find the corresponding DOM element by data-slot value
-      const itemEl = itemElements.find(el => el.getAttribute('data-slot') === i.toString());
-      if (itemEl) {
-        if (itemName.toLowerCase().includes(query)) {
-          // Remove grey-out effect for matching items
-          itemEl.classList.remove('bank-helper-greyed-out');
-        } else {
-          // Add grey-out effect for non-matching items
-          itemEl.classList.add('bank-helper-greyed-out');
+            document.head.appendChild(style);
         }
-      }
+
+        // Input event
+        input.addEventListener('input', e => {
+            const query = input.value.trim().toLowerCase();
+            this.lastQuery = query; // Store the last query
+            this.highlightBankQuery(query);
+        });
+        // If there is a last query, immediately highlight
+        if (this.lastQuery) {
+            this.highlightBankQuery(this.lastQuery);
+        }
     }
-  }
 
-  // Cleanup method
-  destroy() {
-    // Find all bank item elements by data-slot attribute
-    const bankMenu = document.getElementById('hs-bank-menu');
-    if (!bankMenu) return;
+    positionSearchBox(searchContainer: HTMLElement, bankMenu: HTMLElement) {
+        const bankRect = bankMenu.getBoundingClientRect();
 
-    // Query all elements with data-slot attribute
-    const itemElements = Array.from(bankMenu.querySelectorAll('[data-slot]'));
-
-    // If query is empty, remove all grey-out effects
-    itemElements.forEach(el => {
-      el.classList.remove('bank-helper-greyed-out');
-    });
-
-    this.removeSearchBox();
-    
-    // Ensure resize listener is removed
-    if (this.resizeListener) {
-      window.removeEventListener('resize', this.resizeListener);
-      this.resizeListener = null;
+        // Position the search box below the bank menu
+        searchContainer.style.left = `${bankRect.left}px`;
+        searchContainer.style.top = `${bankRect.bottom + 8}px`;
     }
-  }
+
+    removeSearchBox() {
+        // Remove all instances of the search box (in case of duplicates)
+        const existingSearchBoxes = document.querySelectorAll(
+            '#bank-helper-search-box'
+        );
+        existingSearchBoxes.forEach(box => box.remove());
+
+        this.searchBox = null;
+
+        // Remove resize listener
+        if (this.resizeListener) {
+            window.removeEventListener('resize', this.resizeListener);
+            this.resizeListener = null;
+        }
+    }
+
+    highlightBankQuery(query) {
+        // Get bank items from the game data
+        const bankItems =
+            (document as any).highlite?.gameHooks?.EntityManager?.Instance
+                ?.MainPlayer?._bankItems?.Items || [];
+
+        // Find all bank item elements by data-slot attribute
+        const bankMenu = document.getElementById('hs-bank-menu');
+        if (!bankMenu) return;
+
+        // Query all elements with data-slot attribute
+        const itemElements = Array.from(
+            bankMenu.querySelectorAll('[data-slot]')
+        );
+
+        // If query is empty, remove all grey-out effects
+        if (!query) {
+            itemElements.forEach(el => {
+                el.classList.remove('bank-helper-greyed-out');
+            });
+            return;
+        }
+
+        // Loop through bank items and apply grey-out effect to non-matching items
+        for (let i = 0; i < bankItems.length; i++) {
+            const bankItem = bankItems[i];
+            if (!bankItem) continue; // Skip null/empty slots
+
+            // Get item definition
+            const itemDef = (document as any).highlite?.gameHooks?.ItemDefMap
+                ?.ItemDefMap?.get
+                ? (
+                      document as any
+                  ).highlite.gameHooks.ItemDefMap.ItemDefMap.get(bankItem._id)
+                : null;
+
+            const itemName = itemDef
+                ? itemDef._nameCapitalized ||
+                  itemDef._name ||
+                  `Item ${bankItem._id}`
+                : `Item ${bankItem._id}`;
+
+            // Find the corresponding DOM element by data-slot value
+            const itemEl = itemElements.find(
+                el => el.getAttribute('data-slot') === i.toString()
+            );
+            if (itemEl) {
+                if (itemName.toLowerCase().includes(query)) {
+                    // Remove grey-out effect for matching items
+                    itemEl.classList.remove('bank-helper-greyed-out');
+                } else {
+                    // Add grey-out effect for non-matching items
+                    itemEl.classList.add('bank-helper-greyed-out');
+                }
+            }
+        }
+    }
+
+    // Cleanup method
+    destroy() {
+        // Find all bank item elements by data-slot attribute
+        const bankMenu = document.getElementById('hs-bank-menu');
+        if (!bankMenu) return;
+
+        // Query all elements with data-slot attribute
+        const itemElements = Array.from(
+            bankMenu.querySelectorAll('[data-slot]')
+        );
+
+        // If query is empty, remove all grey-out effects
+        itemElements.forEach(el => {
+            el.classList.remove('bank-helper-greyed-out');
+        });
+
+        this.removeSearchBox();
+
+        // Ensure resize listener is removed
+        if (this.resizeListener) {
+            window.removeEventListener('resize', this.resizeListener);
+            this.resizeListener = null;
+        }
+    }
 }

--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -301,7 +301,6 @@ export class BankSearch extends Plugin {
             bankMenu.querySelectorAll('[data-slot]')
         );
 
-        // If query is empty, remove all grey-out effects
         itemElements.forEach(el => {
             el.classList.remove('bank-helper-greyed-out');
         });

--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -8,6 +8,7 @@ export class BankSearch extends Plugin {
   private searchBox: HTMLElement | null = null;
   private observer: MutationObserver | null = null;
   private resizeListener: (() => void) | null = null;
+  private lastQuery: string = "";
 
 
   start(): void {
@@ -15,6 +16,9 @@ export class BankSearch extends Plugin {
         return;
     }
     this.setupBankObserver();
+  }
+
+  init(): void {
   }
 
   stop(): void {
@@ -137,6 +141,7 @@ export class BankSearch extends Plugin {
     input.classList.add('bank-helper-search-input');
     input.style.width = '180px';
     input.style.outline = 'none';
+    input.value = this.lastQuery; // Set input value to last query
 
     // Prevent game from processing keystrokes while typing
     input.addEventListener('keydown', (e) => e.stopPropagation());
@@ -225,8 +230,13 @@ export class BankSearch extends Plugin {
     // Input event
     input.addEventListener('input', (e) => {
       const query = input.value.trim().toLowerCase();
+      this.lastQuery = query; // Store the last query
       this.highlightBankQuery(query);
     });
+    // If there is a last query, immediately highlight
+    if (this.lastQuery) {
+      this.highlightBankQuery(this.lastQuery);
+    }
   }
 
   positionSearchBox(searchContainer: HTMLElement, bankMenu: HTMLElement) {

--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -1,0 +1,313 @@
+import { Plugin } from "../core/interfaces/highlite/plugin/plugin.class";
+
+
+export class BankSearch extends Plugin {
+  pluginName = "Bank Search";
+  author = "Oatelaus";
+
+  private searchBox: HTMLElement | null = null;
+  private observer: MutationObserver | null = null;
+  private resizeListener: (() => void) | null = null;
+
+
+  start(): void {
+    if (!this.settings.enable.value) {
+        return;
+    }
+    this.setupBankObserver();
+  }
+
+  stop(): void {
+    this.destroy()
+  }
+  constructor() {
+      super();
+  }
+
+  setupBankObserver() {
+    // Find the bank menu
+    const bankMenu = document.getElementById('hs-bank-menu');
+    if (!bankMenu) {
+      // Try again later if not found
+      setTimeout(() => this.setupBankObserver(), 1000);
+      return;
+    }
+
+    // Create mutation observer to watch for bank visibility changes
+    this.observer = new MutationObserver((mutations) => {
+      // Check if bank menu was removed
+      const bankMenuStillExists = document.getElementById('hs-bank-menu');
+      if (!bankMenuStillExists) {
+        this.removeSearchBox();
+        return;
+      }
+      
+      this.updateSearchBoxVisibility();
+    });
+
+    // Observe changes to the bank menu's style and class attributes
+    this.observer.observe(bankMenu, {
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+      subtree: false
+    });
+
+    // Also watch for changes to the bank menu's display property
+    this.observer.observe(bankMenu.parentElement || bankMenu, {
+      attributes: true,
+      attributeFilter: ['style', 'class'],
+      subtree: true
+    });
+
+    // Watch for when the bank menu is removed from DOM
+    this.observer.observe(document.body, {
+      childList: true,
+      subtree: true
+    });
+
+    // Initial check
+    this.updateSearchBoxVisibility();
+  }
+
+  updateSearchBoxVisibility() {
+    const bankMenu = document.getElementById('hs-bank-menu');
+    if (!bankMenu) {
+      this.removeSearchBox();
+      return;
+    }
+
+    // Check if bank is visible
+    const isVisible = this.isBankVisible(bankMenu);
+
+    if (isVisible && !this.searchBox) {
+      this.injectSearchBox();
+    } else if (!isVisible && this.searchBox) {
+      this.removeSearchBox();
+    }
+  }
+
+  isBankVisible(bankMenu: HTMLElement): boolean {
+    // Check if the bank menu is visible
+    const style = window.getComputedStyle(bankMenu);
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return false;
+    }
+
+    // Check if parent containers are visible
+    let parent = bankMenu.parentElement;
+    while (parent) {
+      const parentStyle = window.getComputedStyle(parent);
+      if (parentStyle.display === 'none' || parentStyle.visibility === 'hidden') {
+        return false;
+      }
+      parent = parent.parentElement;
+    }
+
+    // Check if bank menu has any content (indicating it's actually open)
+    const hasItems = bankMenu.querySelectorAll('[data-slot]').length > 0;
+    return hasItems;
+  }
+
+  injectSearchBox() {
+    // Prevent duplicate injection - check both internal reference and DOM presence
+    if (this.searchBox || document.getElementById('bank-helper-search-box')) return;
+
+    // Find the bank menu container to position relative to it
+    const bankMenu = document.getElementById('hs-bank-menu');
+    if (!bankMenu) return;
+
+    // Create the search box container
+    const searchContainer = document.createElement('div');
+    searchContainer.id = 'bank-helper-search-box';
+    searchContainer.classList.add('hs-menu');
+    searchContainer.classList.add('bank-helper-search-container');
+    this.searchBox = searchContainer;
+    searchContainer.style.position = 'fixed';
+    searchContainer.style.zIndex = '9999';
+    searchContainer.style.display = 'flex';
+    searchContainer.style.alignItems = 'center';
+    searchContainer.style.gap = '8px';
+    searchContainer.style.width = '300px';
+    searchContainer.style.boxSizing = 'border-box';
+
+    // Create the input
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Find bank item...';
+    input.classList.add('bank-helper-search-input');
+    input.style.width = '180px';
+    input.style.outline = 'none';
+
+    // Prevent game from processing keystrokes while typing
+    input.addEventListener('keydown', (e) => e.stopPropagation());
+    input.addEventListener('keyup', (e) => e.stopPropagation());
+    input.addEventListener('keypress', (e) => e.stopPropagation());
+
+    // Add focus styling and prevent focus stealing (matching other plugins)
+    input.addEventListener('focus', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      input.classList.add('bank-helper-search-input-focused');
+    });
+    input.addEventListener('blur', () => {
+      input.classList.remove('bank-helper-search-input-focused');
+    });
+
+    // Prevent focus stealing on mousedown
+    searchContainer.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      input.focus();
+    });
+
+    // Add search icon
+    const icon = document.createElement('span');
+    icon.textContent = '🔍';
+    icon.classList.add('bank-helper-search-icon');
+
+    searchContainer.appendChild(input);
+    searchContainer.appendChild(icon);
+    
+    // Position the search box below the bank menu
+    this.positionSearchBox(searchContainer, bankMenu);
+    
+    // Append to document body to avoid overflow clipping
+    document.body.appendChild(searchContainer);
+    
+    // Add resize listener to reposition search box
+    this.resizeListener = () => {
+      if (this.searchBox) {
+        const bankMenu = document.getElementById('hs-bank-menu');
+        if (bankMenu) {
+          this.positionSearchBox(this.searchBox, bankMenu);
+        }
+      }
+    };
+    window.addEventListener('resize', this.resizeListener);
+
+    // Add highlight style
+    if (!document.getElementById('bank-helper-highlight-style')) {
+      const style = document.createElement('style');
+      style.id = 'bank-helper-highlight-style';
+      style.textContent = `
+        .bank-helper-search-container {
+          padding: 0px;
+        }
+        
+        .bank-helper-search-input {
+          padding: 6px 10px;
+          border: 1px solid #555;
+          border-radius: 4px;
+          background: #222;
+          color: #fff;
+          font-size: 14px;
+        }
+        
+        .bank-helper-search-input-focused {
+          border: 1px solid #4a9eff !important;
+          box-shadow: 0 0 0 2px rgba(74, 158, 255, 0.2) !important;
+        }
+
+        .bank-helper-search-icon {
+          font-size: 16px;
+          opacity: 0.7;
+        }
+        
+        .bank-helper-greyed-out {
+          opacity: 0.3 !important;
+          filter: grayscale(100%) !important;
+          transition: opacity 0.2s, filter 0.2s;
+        }
+      `;
+      document.head.appendChild(style);
+    }
+
+    // Input event
+    input.addEventListener('input', (e) => {
+      const query = input.value.trim().toLowerCase();
+      this.highlightBankQuery(query);
+    });
+  }
+
+  positionSearchBox(searchContainer: HTMLElement, bankMenu: HTMLElement) {
+    const bankRect = bankMenu.getBoundingClientRect();
+    
+    // Position the search box below the bank menu
+    searchContainer.style.left = `${bankRect.left}px`;
+    searchContainer.style.top = `${bankRect.bottom + 8}px`;
+  }
+
+  removeSearchBox() {
+    // Remove all instances of the search box (in case of duplicates)
+    const existingSearchBoxes = document.querySelectorAll('#bank-helper-search-box');
+    existingSearchBoxes.forEach(box => box.remove());
+    
+    this.searchBox = null;
+    
+    // Remove resize listener
+    if (this.resizeListener) {
+      window.removeEventListener('resize', this.resizeListener);
+      this.resizeListener = null;
+    }
+  }
+
+  highlightBankQuery(query) {
+    // Get bank items from the game data
+    const bankItems = ((document as any).highlite?.gameHooks?.EntityManager?.Instance?.MainPlayer?._bankItems?.Items) || [];
+    
+    // Find all bank item elements by data-slot attribute
+    const bankMenu = document.getElementById('hs-bank-menu');
+    if (!bankMenu) return;
+    
+    // Query all elements with data-slot attribute
+    const itemElements = Array.from(bankMenu.querySelectorAll('[data-slot]'));
+    
+    // If query is empty, remove all grey-out effects
+    if (!query) {
+      itemElements.forEach(el => {
+        el.classList.remove('bank-helper-greyed-out');
+      });
+      return;
+    }
+    
+    // Loop through bank items and apply grey-out effect to non-matching items
+    for (let i = 0; i < bankItems.length; i++) {
+      const bankItem = bankItems[i];
+      if (!bankItem) continue; // Skip null/empty slots
+      
+      // Get item definition
+      const itemDef = ((document as any).highlite?.gameHooks?.ItemDefMap?.ItemDefMap?.get)
+        ? (document as any).highlite.gameHooks.ItemDefMap.ItemDefMap.get(bankItem._id)
+        : null;
+      
+      const itemName = itemDef ? (itemDef._nameCapitalized || itemDef._name || `Item ${bankItem._id}`) : `Item ${bankItem._id}`;
+      
+      // Find the corresponding DOM element by data-slot value
+      const itemEl = itemElements.find(el => el.getAttribute('data-slot') === i.toString());
+      if (itemEl) {
+        if (itemName.toLowerCase().includes(query)) {
+          // Remove grey-out effect for matching items
+          itemEl.classList.remove('bank-helper-greyed-out');
+        } else {
+          // Add grey-out effect for non-matching items
+          itemEl.classList.add('bank-helper-greyed-out');
+        }
+      }
+    }
+  }
+
+  // Cleanup method
+  destroy() {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+    this.removeSearchBox();
+    
+    // Ensure resize listener is removed
+    if (this.resizeListener) {
+      window.removeEventListener('resize', this.resizeListener);
+      this.resizeListener = null;
+    }
+  }
+}


### PR DESCRIPTION
Help users find items in their banks by greying out other items.

My first iteration automatically scrolled users to the item they wanted however I did not think this was appropriate.

No fancy pattern matching, just ".includes`

<img width="593" height="424" alt="image" src="https://github.com/user-attachments/assets/87e31b65-56ec-4fa5-aee6-2c8368ab02fe" />

<img width="593" height="424" alt="image" src="https://github.com/user-attachments/assets/9ec0fc9b-52df-4dca-aeb2-cc7ef012d3ef" />

