### PR TITLE
fix(bank-search): refresh highlites on item changes

### DIFF
--- a/src/renderer/client/highlite/plugins/BankSearch.ts
+++ b/src/renderer/client/highlite/plugins/BankSearch.ts
@@ -32,10 +32,23 @@ export class BankSearch extends Plugin {
         }
         this.injectSearchBox();
         this.updateSearchBoxVisibility();
+
+        const mainPlayer = document.highlite?.gameHooks?.EntityManager?.Instance?.MainPlayer;
+        const bankStorage = mainPlayer.BankStorageItems;
+
+        if (mainPlayer && bankStorage) {
+            bankStorage.OnInventoryChangeListener.add(this.updateSearch.bind(this));
+            bankStorage.OnReorganizedItemsListener.add(this.updateSearch.bind(this));
+        }
     }
+
 
     BankUIManager_handleCenterMenuWillBeRemoved() {
         this.destroy();
+    }
+
+    updateSearch() {
+        this.highlightBankQuery(this.lastQuery)
     }
 
     updateSearchBoxVisibility() {
@@ -110,7 +123,7 @@ export class BankSearch extends Plugin {
         input.classList.add('bank-helper-search-input');
         input.style.width = '180px';
         input.style.outline = 'none';
-        input.value = this.lastQuery; // Set input value to last query
+        input.value = ''; // Set input value to last query
 
         // Prevent game from processing keystrokes while typing
         input.addEventListener('keydown', e => e.stopPropagation());
@@ -292,6 +305,16 @@ export class BankSearch extends Plugin {
 
     // Cleanup method
     destroy() {
+        const mainPlayer = document.highlite?.gameHooks?.EntityManager?.Instance?.MainPlayer;
+        const bankStorage = mainPlayer.BankStorageItems;
+
+        if (mainPlayer && bankStorage) {
+            bankStorage.OnInventoryChangeListener.remove(this.updateSearch);
+            bankStorage.OnReorganizedItemsListener.remove(this.updateSearch);
+        }
+
+        this.lastQuery = '';
+
         // Find all bank item elements by data-slot attribute
         const bankMenu = document.getElementById('hs-bank-menu');
         if (!bankMenu) return;


### PR DESCRIPTION
I'm sneaking in a smaller change not mentioned by the commit title, but search no longer persist between banking sessions.