### PR TITLE
feat: Extend the ChatEnhancer with an extended Blocklist functionality

### DIFF
--- a/src/renderer/client/highlite/plugins/ChatEnhancer.ts
+++ b/src/renderer/client/highlite/plugins/ChatEnhancer.ts
@@ -3,7 +3,7 @@ import { SettingsTypes } from '../core/interfaces/highlite/plugin/pluginSettings
 
 export class ChatEnhancer extends Plugin {
     pluginName = 'Chat Enhancer';
-    author = 'JayArrowz & Answerth';
+    author = 'JayArrowz & Answerth & 0rangeYouGlad';
 
     private observers: MutationObserver[] = [];
     private listeners: {
@@ -213,6 +213,13 @@ export class ChatEnhancer extends Plugin {
             type: SettingsTypes.range,
             value: this.CONFIG.DEFAULT_OPACITY * 100,
             callback: () => this.applyStyles(),
+        };
+
+        this.settings.extendedBlockList = {
+            text: 'Extended Block List',
+            type: SettingsTypes.text,
+            value: "",
+            callback: () => this.applyFilters(),
         };
     }
 
@@ -852,6 +859,16 @@ export class ChatEnhancer extends Plugin {
 
             foundNewMessages = true;
             this.processedMessages.add(msgEl);
+
+            // Extended block list handling
+            const playerNameContainer = msgEl.querySelector(
+                '.hs-chat-menu__player-name'
+            ); 
+            const playerName = `${playerNameContainer?.textContent}`.replace("From ", "").replace(":", "").trim();
+            if((this.settings.extendedBlockList.value as string).split(',').some((name) => playerName && name.toUpperCase() === playerName?.toUpperCase())) {
+                msgEl.style.display = 'none';
+                this.log("Blocking message from " + playerName);
+            }
 
             if (
                 !msgEl.dataset.toggleInjected &&


### PR DESCRIPTION
Since the in-game blocklist has a maximum of 50 players, this allows the ChatEnhancer plugin to filter and hide messages by username as well.