### PR TITLE
fix: produce universal build for macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
           "target": "dmg",
           "arch": [
             "x64",
-            "arm64"
+            "arm64",
+            "universal"
           ]
         }
       ]


### PR DESCRIPTION
I'd like to see the performance of a Universal build from a GitHub runner