### PR TITLE
feat(plugin): add ShiftClickDrop plugin

### DIFF
--- a/src/renderer/client/client.ts
+++ b/src/renderer/client/client.ts
@@ -31,6 +31,7 @@ import { CustomCursor } from './highlite/plugins/CustomCursor';
 import { QuickActionMouseTooltip } from './highlite/plugins/QuickActionMouseTooltip';
 import { ExtraInfoBar } from './highlite/plugins/ExtraInfoBar';
 import { SpellTooltips } from './highlite/plugins/SpellTooltips';
+import { ShiftClickDrop } from './highlite/plugins/ShiftClickDrop';
 
 import '@iconify/iconify';
 import '@static/css/index.css';
@@ -80,6 +81,7 @@ const PLUGIN_REGISTRY = [
     { class: QuickActionMouseTooltip, path: './highlite/plugins/QuickActionMouseTooltip' },
     { class: ExtraInfoBar, path: './highlite/plugins/ExtraInfoBar' },
     { class: SpellTooltips, path: './highlite/plugins/SpellTooltips' },
+    { class: ShiftClickDrop, path: './highlite/plugins/ShiftClickDrop' },
 ];
 
 async function obtainGameClient() {

--- a/src/renderer/client/highlite/core/core.ts
+++ b/src/renderer/client/highlite/core/core.ts
@@ -1,4 +1,5 @@
 import { ContextMenuManager } from './managers/game/contextMenuManager';
+import { InventoryManager } from './managers/game/inventoryManager';
 import { HookManager } from './managers/highlite/hookManager';
 import { NotificationManager } from './managers/highlite/notificationManager';
 import { PanelManager } from './managers/highlite/panelManager';
@@ -31,6 +32,7 @@ export class Highlite {
 
         this.hookManager = new HookManager();
         this.contextMenuManager = new ContextMenuManager();
+        this.inventoryManager = new InventoryManager();
         this.notificationManager = new NotificationManager();
         this.pluginManager = new PluginManager();
         this.uiManager = new UIManager();
@@ -61,7 +63,7 @@ export class Highlite {
         this.hookManager.registerClass('CH', 'InventoryItemSpriteManager');
         this.hookManager.registerClass('DP', 'ItemDefMap');
         this.hookManager.registerClass('Oz', 'BankUIManager');
-        // this.hookManager.registerClass("LF", "MainPlayer");
+        this.hookManager.registerClass("LF", "MainPlayer");
         this.hookManager.registerClass('eR', 'GameCameraManager'); // Tip to find: contains call initializeCamera(e ,t)
         this.hookManager.registerClass('xk', 'SpriteSheetManager'); //Tip to find: contains getter PlayerSpritesheetInfo
         this.hookManager.registerClass('bB', 'NpcDefinitionManager'); //Tip to find: _npcDefMap - 5 of these are found, but they are all located in the right class.
@@ -73,6 +75,7 @@ export class Highlite {
         this.hookManager.registerClass('nX', 'ScreenMask');
         this.hookManager.registerClass('iB', 'MagicSkillManager'); // Tip to find: contains BLOOD_TELEPORT_ID
         this.hookManager.registerClass('_z', 'SpellMenuManager'); // Tip to find: contains _handleSpellItemPointerOver
+        this.hookManager.registerClass('Fz', 'Fz');
 
         // Function Hook-ins
         this.hookManager.registerClassOverrideHook(
@@ -148,6 +151,15 @@ export class Highlite {
             'GV',
             'getActionsAndEntitiesAtMousePointer',
             this.contextMenuManager.ActionSorting
+        );
+
+        // TODO: We could also hook into the quicktext handling and wrap
+        // _handleHighSpellInventoryItemPointerOver or similar to give visual
+        // feedback when the user holds shift and has not clicked yet.
+        this.hookManager.registerStaticClassWrapperHook(
+            'Fz',
+            'handleInventoryItemLeftClicked',
+            this.inventoryManager.handleInventoryItemLeftClicked
         );
 
         // Lookup Table Mappings

--- a/src/renderer/client/highlite/core/managers/game/inventoryManager.ts
+++ b/src/renderer/client/highlite/core/managers/game/inventoryManager.ts
@@ -1,0 +1,79 @@
+export class InventoryManager {
+    private static instance: InventoryManager;
+    // FIXME: The mouse input event has this as an attribute which seems like a
+    // more appropriate way to get at this, but it would require wrapping a
+    // higher level input hook which complicates the implementation here and
+    // feels more brittle. This document-global shift-key tracking is a
+    // compromise that seems to work fine in testing.
+    private shiftKeyPressed: boolean = false;
+
+    shiftKeyDrops: boolean = false;
+
+    constructor() {
+        if (InventoryManager.instance) {
+            return InventoryManager.instance;
+        }
+        this.registerEventListeners(this);
+        InventoryManager.instance = this;
+        document.highlite.managers.InventoryManager = this;
+    }
+
+    private registerEventListeners(inventoryManager: InventoryManager) {
+        document.addEventListener('keydown', e => {
+            if (e.key === 'Shift') { inventoryManager.shiftKeyPressed = true; }
+        });
+        document.addEventListener('keyup', e => {
+            if (e.key === 'Shift') { inventoryManager.shiftKeyPressed = false; }
+        });
+    }
+
+    handleInventoryItemLeftClicked(
+        hookName: string,
+        originalThis: any,
+        originalFunction: any,
+        e, t
+    ): void {
+        const wrapped = () => originalFunction.apply(originalThis, [e, t]);
+
+        const inventoryManager = new InventoryManager();
+        const shiftKeyDropsAndIsPressed =
+            inventoryManager.shiftKeyDrops &&
+            inventoryManager.shiftKeyPressed;
+        if (!shiftKeyDropsAndIsPressed) {
+            return wrapped();
+        }
+
+        const GH = document.highlite.gameHooks;
+        const playerStateKinds = document.client.get('BI');
+        const contextMenuEntries = document.client.get('QA');
+
+        const currentState =
+            GH.EntityManager.Instance.MainPlayer.CurrentState.getCurrentState();
+        const clickShouldNotDrop =
+            GH.ItemManager.Instance.IsItemCurrentlySelected ||
+            GH.SpellManager.Instance.IsSpellCurrentlySelected ||
+            e.getMenuType() !== GH.MainPlayer.Inventory ||
+            currentState === playerStateKinds.BankingState ||
+            currentState === playerStateKinds.ShoppingState;
+        if (clickShouldNotDrop) {
+            return wrapped();
+        }
+
+        const slot = e.getSlot();
+        const item = GH.EntityManager.Instance.MainPlayer.Inventory.Items[slot];
+        const itemHasDropAction =
+            item !== null &&
+            item.Def.InventoryActions.includes(contextMenuEntries.drop);
+        if (!itemHasDropAction) {
+            return wrapped();
+        }
+
+        // Replace a call to wrapped with the same call to
+        // invokeInventoryAction that it would make in this context, except we
+        // change the action to 'drop'.
+        GH.ItemManager.Instance.invokeInventoryAction(e.getMenuType(),
+                                                      contextMenuEntries.drop,
+                                                      slot,
+                                                      item);
+    }
+}

--- a/src/renderer/client/highlite/plugins/ShiftClickDrop.ts
+++ b/src/renderer/client/highlite/plugins/ShiftClickDrop.ts
@@ -1,0 +1,22 @@
+import { Plugin } from '../core/interfaces/highlite/plugin/plugin.class';
+import { InventoryManager } from '../core/managers/game/inventoryManager';
+
+export class ShiftClickDrop extends Plugin {
+    pluginName = 'ShiftClickDrop';
+    pluginDescription = 'Hold Shift and Left Click to drop inventory items';
+    author = 'stringy';
+    inventoryManager = new InventoryManager();
+
+    // Initialization
+    init(): void { this.update(); }
+
+    // Startup function when enabled
+    start(): void { this.update(); }
+
+    // Stopping function when disabled
+    stop(): void { this.update(); }
+
+    update() {
+        this.inventoryManager.shiftKeyDrops = this.settings.enable.value;
+    }
+}


### PR DESCRIPTION
An attempt at a shift+click-to-drop plugin.

Some notes:

* There has been no word from Dew on if this is acceptable or not (at least not that I can find).
* The most salient argument I can see against allowing this is that it could provide a speed advantage, but I'd claim this is offset by the fact that the 1-drop-per-tick limit still applies, and that the inventory is still not interactable while a drop packet is in flight. Together these mean that even with the plugin enabled one has to wait quite a while between clicks, or inputs will be eaten.

Known issues:

* The way "shift" being pressed is checked is not ideal, and if one e.g. presses shift, drags the mouse out of the game window onto the HighLite UI while holding it, releases it over the HighLite UI, and then drags it back over the game window it will be "stuck" on until shift is pressed again. The best alternative I can see is to hook into the "dispatch" function which invokes `handleInventoryItemLeftClicked`, which seemed more brittle.
* This adds another hook-management function which overlaps/duplicates parts of the existing ones, it might make sense to refactor these at some point.